### PR TITLE
Return request error as an object

### DIFF
--- a/module/request.js
+++ b/module/request.js
@@ -48,9 +48,8 @@ function Request (application, options) {
                 if (json_body != null) {
                     self.emit('response', json_body);
                 }
-            } else {
-                var error = 'Server response error with status code: ' + response.statusCode + '\n' + body;
-                self.emit('error', error);
+            } else {                
+                self.emit('error', JSON.parse(body));
             }
         });
     });


### PR DESCRIPTION
Wouldn't be easier on client side to have an error returned as an object rather than a mix of a text message and a json response?

I've been struggling how to handle that response, split response on "\n" and json parse the body? For some reason it doesn't work since I'm getting parsing error. Thanks.