### PR TITLE
Add service method to delete/reset all contexts.

### DIFF
--- a/examples/delete_contexts.js
+++ b/examples/delete_contexts.js
@@ -1,0 +1,23 @@
+/*!
+ * apiai
+ * Copyright(c) 2017 http://api.ai/
+ * Apache 2.0 Licensed
+ */
+
+'use strict';
+
+var apiai = require("apiai");
+
+var app = apiai("YOUR_ACCESS_TOKEN");
+
+var request = app.deleteContextsForSession('<UNIQUE SESSION ID>');
+
+request.on('response', function(response) {
+    console.log(response);
+});
+
+request.on('error', function(error) {
+    console.log(error);
+});
+
+request.end();

--- a/examples/delete_contexts.js
+++ b/examples/delete_contexts.js
@@ -10,7 +10,11 @@ var apiai = require("apiai");
 
 var app = apiai("YOUR_ACCESS_TOKEN");
 
-var request = app.deleteContextsForSession('<UNIQUE SESSION ID>');
+var options = {
+    sessionId: '<UNIQE SESSION ID>'
+};
+
+var request = app.deleteContextsRequest(options);
 
 request.on('response', function(response) {
     console.log(response);

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,6 +129,20 @@ declare namespace apiai {
     }
 
     /**
+     * Delete Contexts Request options.
+     */
+    interface DeleteContextsRequestOptions extends RequestOptions {
+        sessionId: string;
+    }
+
+    /**
+     * Delete Contexts Request.
+     */
+    interface DeleteContextsRequest extends JSONApiRequest {
+
+    }
+
+    /**
      * UserEntityEntry model for user entities request.
      */
     interface UserEntityEntry {
@@ -203,6 +217,7 @@ declare namespace apiai {
         textRequest(query: string | [string], options: TextRequestOptions): TextRequest;
         eventRequest(event: Event, options: EventRequestOptions): EventRequest;
         contextsRequest(contexts: [any], options: ContextsRequestOptions): ContextsRequest;
+        deleteContextsRequest(options: DeleteContextsRequestOptions): DeleteContextsRequest;
         userEntitiesRequest(user_entities_body: UserEntitiesBody, options?: UserEntitiesRequestOptions): UserEntitiesRequest;
         ttsRequest(text: string, options: TTSRequestOptions): TTSRequest;
     }

--- a/module/apiai.js
+++ b/module/apiai.js
@@ -15,6 +15,7 @@ var https = require('https');
 var http = require('http');
 
 var ContextsRequest = require('./contexts_request').ContextsRequest;
+var DeleteContextsRequest = require('./delete_contexts_request').DeleteContextsRequest;
 var TextRequest = require('./text_request').TextRequest;
 var EventRequest = require('./event_request').EventRequest;
 var VoiceRequest = require('./voice_request').VoiceRequest;
@@ -131,11 +132,19 @@ Application.prototype.contextsRequest = function(contexts, options) {
 
 /**
  * Delete/Reset all contexts for session by ID.
- * @param  {string} sessionId The session ID to delete contexts
+ * @param  {object} options Options for DeleteContextsRequest. Should contain sessionId.
  * @return {ContextsRequest}           Returns a ContextsRequest object.
  */
-Application.prototype.deleteContextsForSession = function(sessionId) {
-    return this.contextsRequest(null, {method:'DELETE', sessionId:sessionId});
+Application.prototype.deleteContextsRequest = function(options) {
+    var self = this;
+
+    var opt = options || {};
+
+    if (!('endpoint' in opt)) {
+        opt.endpoint = self.endpoint;
+    }
+
+    return new DeleteContextsRequest(self, opt);
 }
 
 /**

--- a/module/apiai.js
+++ b/module/apiai.js
@@ -130,11 +130,12 @@ Application.prototype.contextsRequest = function(contexts, options) {
 };
 
 /**
- * Delete all contexts
- * @return {ContextsRequest}          Returns a ContextsRequest object.
+ * Delete/Reset all contexts for session by ID.
+ * @param  {string} sessionId The session ID to delete contexts
+ * @return {ContextsRequest}           Returns a ContextsRequest object.
  */
-Application.prototype.deleteContextsForSession = function(session) {
-    return this.contextsRequest(null, {method:'DELETE', sessionId:session});
+Application.prototype.deleteContextsForSession = function(sessionId) {
+    return this.contextsRequest(null, {method:'DELETE', sessionId:sessionId});
 }
 
 /**

--- a/module/apiai.js
+++ b/module/apiai.js
@@ -133,8 +133,8 @@ Application.prototype.contextsRequest = function(contexts, options) {
  * Delete all contexts
  * @return {ContextsRequest}          Returns a ContextsRequest object.
  */
-Application.prototype.deleteContexts = function() {
-    return this.contextsRequest(null, {method:'DELETE'});
+Application.prototype.deleteContextsForSession = function(session) {
+    return this.contextsRequest(null, {method:'DELETE', sessionId:session});
 }
 
 /**

--- a/module/apiai.js
+++ b/module/apiai.js
@@ -130,6 +130,14 @@ Application.prototype.contextsRequest = function(contexts, options) {
 };
 
 /**
+ * Delete all contexts
+ * @return {ContextsRequest}          Returns a ContextsRequest object.
+ */
+Application.prototype.deleteContexts = function() {
+    return this.contextsRequest(null, {method:'DELETE'});
+}
+
+/**
  * [textRequest description]
  * @param  {[type]} query   [description]
  * @param  {[type]} options [description]

--- a/module/contexts_request.js
+++ b/module/contexts_request.js
@@ -18,7 +18,6 @@ function ContextsRequest(application, contexts, options) {
 
     self.contexts = contexts;
     self.sessionId = options.sessionId;
-    self.method = options.method || 'POST';
 
     ContextsRequest.super_.apply(this, [application, options]);
 }
@@ -35,7 +34,7 @@ ContextsRequest.prototype._requestOptions = function() {
     var request_options = ContextsRequest.super_.prototype._requestOptions.apply(this, arguments);
 
     request_options.path = this.endpoint + 'contexts?sessionId=' + this.sessionId;
-    request_options.method = this.method;
+    request_options.method = 'POST';
 
     return request_options;
 };
@@ -43,9 +42,7 @@ ContextsRequest.prototype._requestOptions = function() {
 ContextsRequest.prototype.end = function() {
     var self = this;
 
-    if (self.method === 'POST') {
-        self.write(JSON.stringify(self.contexts));
-    }
+    self.write(JSON.stringify(self.contexts));
 
     ContextsRequest.super_.prototype.end.apply(this, arguments);
 };

--- a/module/contexts_request.js
+++ b/module/contexts_request.js
@@ -18,6 +18,7 @@ function ContextsRequest(application, contexts, options) {
 
     self.contexts = contexts;
     self.sessionId = options.sessionId;
+    self.method = options.method || 'POST';
 
     ContextsRequest.super_.apply(this, [application, options]);
 }
@@ -34,7 +35,7 @@ ContextsRequest.prototype._requestOptions = function() {
     var request_options = ContextsRequest.super_.prototype._requestOptions.apply(this, arguments);
 
     request_options.path = this.endpoint + 'contexts?sessionId=' + this.sessionId;
-    request_options.method = 'POST';
+    request_options.method = this.method;
 
     return request_options;
 };
@@ -42,7 +43,9 @@ ContextsRequest.prototype._requestOptions = function() {
 ContextsRequest.prototype.end = function() {
     var self = this;
 
-    self.write(JSON.stringify(self.contexts));
+    if (self.method === 'POST') {
+        self.write(JSON.stringify(self.contexts));
+    }
 
     ContextsRequest.super_.prototype.end.apply(this, arguments);
 };

--- a/module/delete_contexts_request.js
+++ b/module/delete_contexts_request.js
@@ -37,9 +37,3 @@ DeleteContextsRequest.prototype._requestOptions = function() {
 
     return request_options;
 };
-
-DeleteContextsRequest.prototype.end = function() {
-    var self = this;
-
-    DeleteContextsRequest.super_.prototype.end.apply(this, arguments);
-};

--- a/module/delete_contexts_request.js
+++ b/module/delete_contexts_request.js
@@ -1,0 +1,45 @@
+/*!
+ * apiai
+ * Copyright(c) 2015 http://api.ai/
+ * Apache 2.0 Licensed
+ */
+
+'use strict';
+
+var JSONApiRequest = require('./json_api_request').JSONApiRequest;
+var util = require('util');
+
+exports.DeleteContextsRequest = module.exports.DeleteContextsRequest = DeleteContextsRequest;
+
+util.inherits(DeleteContextsRequest, JSONApiRequest);
+
+function DeleteContextsRequest(application, options) {
+    var self = this;
+
+    self.sessionId = options.sessionId;
+
+    DeleteContextsRequest.super_.apply(this, [application, options]);
+}
+
+DeleteContextsRequest.prototype._headers = function() {
+    var headers = DeleteContextsRequest.super_.prototype._headers.apply(this, arguments);
+
+    headers['Content-Type'] = 'application/json; charset=utf-8';
+
+    return headers;
+};
+
+DeleteContextsRequest.prototype._requestOptions = function() {
+    var request_options = DeleteContextsRequest.super_.prototype._requestOptions.apply(this, arguments);
+
+    request_options.path = this.endpoint + 'contexts?sessionId=' + this.sessionId;
+    request_options.method = 'DELETE';
+
+    return request_options;
+};
+
+DeleteContextsRequest.prototype.end = function() {
+    var self = this;
+
+    DeleteContextsRequest.super_.prototype.end.apply(this, arguments);
+};


### PR DESCRIPTION
I have added a prototype function to the apiai service module to delete/reset all active contexts. The update modifies the `ContextsRequest` object to accept a `method` option to pass *DELETE* as the method. This will default to *POST* if no method option is given. The `end` method also checks if the request method is *POST* before writing the body content. 

The new method is named `deleteContextsForSession` and I have included an example. 